### PR TITLE
Add options to QueryRelevantDocuments, add a new WithScoreThreshold option

### DIFF
--- a/examples/qdrant/main.go
+++ b/examples/qdrant/main.go
@@ -72,7 +72,9 @@ func main() {
 	}
 
 	// Query the most relevant documents based on a given embedding
-	retrievedDocs, err := vectorDB.QueryRelevantDocuments(ctx, queryEmbedding, 5, collection_name)
+	retrievedDocs, err := vectorDB.QueryRelevantDocuments(
+		ctx, queryEmbedding, collection_name,
+		db.WithLimit(5), db.WithScoreThreshold(0.7))
 	if err != nil {
 		log.Fatalf("Failed to query documents: %v", err)
 	}


### PR DESCRIPTION
It is useful to either retrieve only the relevant documents or none at all to avoid tainting the conversation with documents that are not relevant to add.

To allow that, this patch converts the existing Limit parameter to a functional option and adds a new one WithScoreThreshold that allows to set the minimal required cosine distance between the document and the vectorized query.